### PR TITLE
a few code cleanups

### DIFF
--- a/plantbuild
+++ b/plantbuild
@@ -43,7 +43,7 @@ while getopts "v:a:b:d:l:" opt; do
   esac
 done
 
-# jsonnetfile="$(pwd)/$jsonnetfile"
+
 if [ -z "$jsonnetfile" ]; then
     echo "$usage"
     exit 1
@@ -64,14 +64,15 @@ tag_version=$(git describe --tags --exact-match 2>/dev/null)
 dir=$(dirname "$jsonnetfile")
 filename=$(basename "$jsonnetfile")
 
-if test -z "$KUBECTL_BASH"; then
+if [ -z "$KUBECTL_BASH" ]; then
     KUBECTL_BASH="/bin/bash"
 fi
 dockerimage='theplant/plantbuild'
+
 # functions
 
 push_image() {
-    build_image "$1" && \
+    build_image "$1"
     docker run -i --rm -e RUN="/src/$filename" -e VERSION="$1" -v "$(pwd)/$dir:/src" "$dockerimage$buildversion" | docker-compose -f - push "$dcservice"
 }
 
@@ -81,14 +82,14 @@ build_image() {
 
 show() {
     local source=/src/$2
-    if test "$2" == '-'; then
+    if [ "$2" = '-' ]; then
         source='-'
     fi
     docker run -i --rm -e RUN=$source -e VERSION="$1" -v "$(pwd)/$dir:/src" "$dockerimage$buildversion"
 }
 
 _k() {
-    if test -z "$2"; then
+    if [ -z "$2" ]; then
         echo "kubectl $1"
         echo "kubectl $1" | $KUBECTL_BASH
     else
@@ -114,8 +115,8 @@ case $subcommand in
         docker run --rm -e RUN="/src/$filename" -e VERSION="$version" -v "$(pwd)/$dir:/src" "$dockerimage$buildversion" | docker-compose -f - run "$app"_test
         ;;
     build)
-        build_image "$version" && \
-        if [ "$push_to_latest_tag" == true ] ; then
+        build_image "$version"
+        if [ "$push_to_latest_tag" = true ] ; then
             build_image "latest"
         fi
         if [ -n "$tag_version" ]; then
@@ -123,8 +124,8 @@ case $subcommand in
         fi
         ;;
     push)
-        push_image "$version" && \
-        if [ "$push_to_latest_tag" == true ] ; then
+        push_image "$version"
+        if [ "$push_to_latest_tag" = true ] ; then
             push_image "latest"
         fi
         if [ -n "$tag_version" ]; then

--- a/plantbuild
+++ b/plantbuild
@@ -17,32 +17,31 @@ push_to_latest_tag=true
 usage="Usage: plantbuild run/build/push/show/k8scommit/k8s_cm_patch/k8s_set_images/k8s_apply ./plantbuild/test.jsonnet -a=app1 -v=1.0.0"
 
 while getopts "v:a:b:d:l:" opt; do
-  case $opt in
-    v )
+    case $opt in
+    v)
         version=$OPTARG
-      ;;
-    a )
+        ;;
+    a)
         app=$OPTARG
         if [ -n "$app" ]; then
             dcservice=build_image_$OPTARG
         fi
-      ;;
-    b )
+        ;;
+    b)
         buildversion=":$OPTARG"
-      ;;
-    d )
+        ;;
+    d)
         dryrun=$OPTARG
-      ;;
-    l )
+        ;;
+    l)
         push_to_latest_tag=$OPTARG
-      ;;
-    \? )
+        ;;
+    \?)
         echo "$usage"
         exit 1
-      ;;
-  esac
+        ;;
+    esac
 done
-
 
 if [ -z "$jsonnetfile" ]; then
     echo "$usage"
@@ -54,7 +53,7 @@ if ! [ -e "$jsonnetfile" ]; then
     exit 1
 fi
 
-githash7=$(git rev-parse HEAD|cut -c 1-7)
+githash7=$(git rev-parse HEAD | cut -c 1-7)
 if [ -z "$version" ]; then
     version=$githash7
 fi
@@ -111,74 +110,83 @@ k8scommit() {
 }
 
 case $subcommand in
-    run)
-        docker run --rm -e RUN="/src/$filename" -e VERSION="$version" -v "$(pwd)/$dir:/src" "$dockerimage$buildversion" | docker-compose -f - run "$app"_test
-        ;;
-    build)
-        build_image "$version"
-        if [ "$push_to_latest_tag" = true ] ; then
-            build_image "latest"
-        fi
-        if [ -n "$tag_version" ]; then
-            build_image "$tag_version"
-        fi
-        ;;
-    push)
-        push_image "$version"
-        if [ "$push_to_latest_tag" = true ] ; then
-            push_image "latest"
-        fi
-        if [ -n "$tag_version" ]; then
-            push_image "$tag_version"
-        fi
-        ;;
-    show)
-        show "$version" "$filename"
-        ;;
-    k8scommit)
-        if k8scommit; then
-            exit 0
-        else
-            exit 1
-        fi
-        ;;
-    k8s_set_images)
-        show "$version" "$filename" | jq -r '.commands[]' | while read -r i; do
-            _k "$i"
-        done
-        ;;
-    k8s_cm_patch)
-        if k8scommit; then
-            meta=$(show "$githash7" "$filename" | jq ".metadata")
-            namespace=$(echo "$meta" | jq -r ".namespace")
-            configmap=$(echo "$meta" | jq -r ".name")
 
-            patchscript='local k8s = import "k8s.jsonnet"; k8s.patch_deployment_env("'$configmap'")'
-            resourceName=$(echo "$meta" | jq -r ".labels.deployment")
-            k8sresource='deployment'
-            if echo "$meta" | jq -e -r ".labels.cronjob"; then
-                k8sresource='cronjob'
-                resourceName=$(echo "$meta" | jq -r ".labels.cronjob")
-                patchscript='local k8s = import "k8s.jsonnet"; k8s.patch_cronjob_env("'$configmap'")'
-            fi
+run)
+    docker run --rm -e RUN="/src/$filename" -e VERSION="$version" -v "$(pwd)/$dir:/src" "$dockerimage$buildversion" | docker-compose -f - run "$app"_test
+    ;;
 
-            if echo "$meta" | jq -e -r ".labels.job"; then
-                k8sresource='job'
-                resourceName=$(echo "$meta" | jq -r ".labels.job")
-                patchscript='local k8s = import "k8s.jsonnet"; k8s.patch_job_env("'$configmap'")'
-            fi
+build)
+    build_image "$version"
+    if [ "$push_to_latest_tag" = true ]; then
+        build_image "latest"
+    fi
+    if [ -n "$tag_version" ]; then
+        build_image "$tag_version"
+    fi
+    ;;
 
-            patch=$(echo "$patchscript" | show "$githash7" '-')
-            echo "patching with: $patch"
-            _k "-n $namespace patch $k8sresource/$resourceName --record --type=json -p $patch"
-        fi
-        ;;
-    k8s_apply)
-        content=$(show "$version" "$filename")
-        _k "apply --record -f - --dry-run=$dryrun" "$content"
-        ;;
-    * )
-        echo "$usage"
+push)
+    push_image "$version"
+    if [ "$push_to_latest_tag" = true ]; then
+        push_image "latest"
+    fi
+    if [ -n "$tag_version" ]; then
+        push_image "$tag_version"
+    fi
+    ;;
+
+show)
+    show "$version" "$filename"
+    ;;
+
+k8scommit)
+    if k8scommit; then
+        exit 0
+    else
         exit 1
-        ;;
+    fi
+    ;;
+
+k8s_set_images)
+    show "$version" "$filename" | jq -r '.commands[]' | while read -r i; do
+        _k "$i"
+    done
+    ;;
+
+k8s_cm_patch)
+    if k8scommit; then
+        meta=$(show "$githash7" "$filename" | jq ".metadata")
+        namespace=$(echo "$meta" | jq -r ".namespace")
+        configmap=$(echo "$meta" | jq -r ".name")
+
+        patchscript='local k8s = import "k8s.jsonnet"; k8s.patch_deployment_env("'$configmap'")'
+        resourceName=$(echo "$meta" | jq -r ".labels.deployment")
+        k8sresource='deployment'
+        if echo "$meta" | jq -e -r ".labels.cronjob"; then
+            k8sresource='cronjob'
+            resourceName=$(echo "$meta" | jq -r ".labels.cronjob")
+            patchscript='local k8s = import "k8s.jsonnet"; k8s.patch_cronjob_env("'$configmap'")'
+        fi
+
+        if echo "$meta" | jq -e -r ".labels.job"; then
+            k8sresource='job'
+            resourceName=$(echo "$meta" | jq -r ".labels.job")
+            patchscript='local k8s = import "k8s.jsonnet"; k8s.patch_job_env("'$configmap'")'
+        fi
+
+        patch=$(echo "$patchscript" | show "$githash7" '-')
+        echo "patching with: $patch"
+        _k "-n $namespace patch $k8sresource/$resourceName --record --type=json -p $patch"
+    fi
+    ;;
+
+k8s_apply)
+    content=$(show "$version" "$filename")
+    _k "apply --record -f - --dry-run=$dryrun" "$content"
+    ;;
+*)
+    echo "$usage"
+    exit 1
+    ;;
+
 esac

--- a/plantbuild
+++ b/plantbuild
@@ -23,7 +23,7 @@ while getopts "v:a:b:d:l:" opt; do
       ;;
     a )
         app=$OPTARG
-        if ! [ -z $app ]; then
+        if [ -n "$app" ]; then
             dcservice=build_image_$OPTARG
         fi
       ;;
@@ -44,25 +44,25 @@ while getopts "v:a:b:d:l:" opt; do
 done
 
 # jsonnetfile="$(pwd)/$jsonnetfile"
-if [ -z $jsonnetfile ]; then
+if [ -z "$jsonnetfile" ]; then
     echo "$usage"
     exit 1
 fi
 
-if ! [ -e $jsonnetfile ]; then
+if ! [ -e "$jsonnetfile" ]; then
     echo "$jsonnetfile not exists"
     exit 1
 fi
 
 githash7=$(git rev-parse HEAD|cut -c 1-7)
-if [ -z $version ]; then
+if [ -z "$version" ]; then
     version=$githash7
 fi
 
 tag_version=$(git describe --tags --exact-match 2>/dev/null)
 
-dir=`dirname $jsonnetfile`
-filename=`basename $jsonnetfile`
+dir=$(dirname "$jsonnetfile")
+filename=$(basename "$jsonnetfile")
 
 if test -z "$KUBECTL_BASH"; then
     KUBECTL_BASH="/bin/bash"
@@ -71,20 +71,20 @@ dockerimage='theplant/plantbuild'
 # functions
 
 push_image() {
-    build_image $1 && \
-    docker run -i --rm -e RUN=/src/$filename -e VERSION=$1 -v `pwd`/$dir:/src $dockerimage$buildversion | docker-compose -f - push $dcservice
+    build_image "$1" && \
+    docker run -i --rm -e RUN="/src/$filename" -e VERSION="$1" -v "$(pwd)/$dir:/src" "$dockerimage$buildversion" | docker-compose -f - push "$dcservice"
 }
 
 build_image() {
-    docker run -i --rm -e RUN=/src/$filename -e VERSION=$1 -v `pwd`/$dir:/src $dockerimage$buildversion | docker-compose -f - build $dcservice
+    docker run -i --rm -e RUN="/src/$filename" -e VERSION="$1" -v "$(pwd)/$dir:/src" "$dockerimage$buildversion" | docker-compose -f - build "$dcservice"
 }
 
 show() {
     local source=/src/$2
-    if test $2 == '-'; then
+    if test "$2" == '-'; then
         source='-'
     fi
-    docker run -i --rm -e RUN=$source -e VERSION=$1 -v `pwd`/$dir:/src $dockerimage$buildversion
+    docker run -i --rm -e RUN=$source -e VERSION="$1" -v "$(pwd)/$dir:/src" "$dockerimage$buildversion"
 }
 
 _k() {
@@ -93,18 +93,17 @@ _k() {
         echo "kubectl $1" | $KUBECTL_BASH
     else
         content=$(printf "%q" "$2")
-        # echo "echo $content | kubectl $1"
         echo "echo $content | kubectl $1" | $KUBECTL_BASH
     fi
 }
 
 k8scommit() {
-    content=$(show 'latest' $filename)
+    content=$(show 'latest' "$filename")
     if _k "apply -f -" "$content" | grep " unchanged"; then
         echo "latest not changed, so won't create new versions"
         return 1
     else
-        content=$(show $githash7 $filename)
+        content=$(show "$githash7" "$filename")
         _k "apply -f -" "$content"
         return 0
     fi
@@ -112,28 +111,28 @@ k8scommit() {
 
 case $subcommand in
     run)
-        docker run --rm -e RUN=/src/$filename -e VERSION=$version -v `pwd`/$dir:/src $dockerimage$buildversion | docker-compose -f - run "$app"_test
+        docker run --rm -e RUN="/src/$filename" -e VERSION="$version" -v "$(pwd)/$dir:/src" "$dockerimage$buildversion" | docker-compose -f - run "$app"_test
         ;;
     build)
-        build_image $version && \
+        build_image "$version" && \
         if [ "$push_to_latest_tag" == true ] ; then
             build_image "latest"
         fi
-        if ! [ -z $tag_version ]; then
-            build_image $tag_version
+        if [ -n "$tag_version" ]; then
+            build_image "$tag_version"
         fi
         ;;
     push)
-        push_image $version && \
+        push_image "$version" && \
         if [ "$push_to_latest_tag" == true ] ; then
             push_image "latest"
         fi
-        if ! [ -z $tag_version ]; then
-            push_image $tag_version
+        if [ -n "$tag_version" ]; then
+            push_image "$tag_version"
         fi
         ;;
     show)
-        show $version $filename
+        show "$version" "$filename"
         ;;
     k8scommit)
         if k8scommit; then
@@ -143,38 +142,38 @@ case $subcommand in
         fi
         ;;
     k8s_set_images)
-        show $version $filename | jq -r '.commands[]' | while read i; do
+        show "$version" "$filename" | jq -r '.commands[]' | while read -r i; do
             _k "$i"
         done
         ;;
     k8s_cm_patch)
         if k8scommit; then
-            meta=$(show $githash7 $filename | jq ".metadata")
-            namespace=$(echo $meta | jq -r ".namespace")
-            configmap=$(echo $meta | jq -r ".name")
+            meta=$(show "$githash7" "$filename" | jq ".metadata")
+            namespace=$(echo "$meta" | jq -r ".namespace")
+            configmap=$(echo "$meta" | jq -r ".name")
 
             patchscript='local k8s = import "k8s.jsonnet"; k8s.patch_deployment_env("'$configmap'")'
-            resourceName=$(echo $meta | jq -r ".labels.deployment")
+            resourceName=$(echo "$meta" | jq -r ".labels.deployment")
             k8sresource='deployment'
-            if echo $meta | jq -e -r ".labels.cronjob"; then
+            if echo "$meta" | jq -e -r ".labels.cronjob"; then
                 k8sresource='cronjob'
-                resourceName=$(echo $meta | jq -r ".labels.cronjob")
+                resourceName=$(echo "$meta" | jq -r ".labels.cronjob")
                 patchscript='local k8s = import "k8s.jsonnet"; k8s.patch_cronjob_env("'$configmap'")'
             fi
 
-            if echo $meta | jq -e -r ".labels.job"; then
+            if echo "$meta" | jq -e -r ".labels.job"; then
                 k8sresource='job'
-                resourceName=$(echo $meta | jq -r ".labels.job")
+                resourceName=$(echo "$meta" | jq -r ".labels.job")
                 patchscript='local k8s = import "k8s.jsonnet"; k8s.patch_job_env("'$configmap'")'
             fi
 
-            patch=$(echo $patchscript | show $githash7 '-')
-            echo "patching with: ""$patch"
-            _k "-n $namespace patch $k8sresource/$resourceName --record --type=json -p \"$(echo $patch)\""
+            patch=$(echo "$patchscript" | show "$githash7" '-')
+            echo "patching with: $patch"
+            _k "-n $namespace patch $k8sresource/$resourceName --record --type=json -p $patch"
         fi
         ;;
     k8s_apply)
-        content=$(show $version $filename)
+        content=$(show "$version" "$filename")
         _k "apply --record -f - --dry-run=$dryrun" "$content"
         ;;
     * )


### PR DESCRIPTION
- fixed shellcheck warnings
- made style more consistent
- formatted whitespace

the first and the third commit is somewhat trivial, but the second one is trying to resolve a regression which related to https://github.com/theplant/plantbuild/commit/e600bd09c754dd91d64e69b8b7ae0e829e2ac6f4: in a CI job, the docker build failed but the script won't exit on error, instead it will still run what's left.