### PR TITLE
k8s: added ingress field `pathType`

### DIFF
--- a/jsonnetlib/k8s.jsonnet
+++ b/jsonnetlib/k8s.jsonnet
@@ -398,6 +398,7 @@ cfg {
           paths: [
             {
               path: path,
+              pathType: 'Exact',
               backend: {
                 service: {
                   name: name,


### PR DESCRIPTION
... as it seems this field is required for v1

x-ref: https://github.com/theplant/plantbuild/pull/40