### PR TITLE
k8s: allow overwrite cronjob spec

### DIFF
--- a/example/k8s/cronjob.jsonnet
+++ b/example/k8s/cronjob.jsonnet
@@ -5,12 +5,15 @@ k8s.cronjob(
   name='cronjob1',
   configmap='cm-cronjob1-latest',
   schedule='* * * * *',
+  cronjobSpec={
+    concurrencyPolicy: 'Forbid',
+  },
   container={
     image: 'alpine',
     args: [
       '/bin/sh',
       '-c',
-      'echo "Hello world $HelloName"',
+      "echo 'Hello world $HelloName'",
     ],
   },
 )

--- a/jsonnetlib/config.jsonnet
+++ b/jsonnetlib/config.jsonnet
@@ -19,6 +19,7 @@ assert std.length(v) > 0 : 'version is empty';
   successfulJobsHistoryLimit: 1,
   projectRoot: '/go/src/github.com',
   podSpec: {},
+  cronjobSpec: {},
   terminationGracePeriodSeconds: 30,
   ingressClassName: 'nginx',
   pathType: 'ImplementationSpecific',

--- a/jsonnetlib/k8s.jsonnet
+++ b/jsonnetlib/k8s.jsonnet
@@ -77,6 +77,7 @@ cfg {
     container={},
     volumes=[],
     podSpec=root.podSpec,
+    cronjobSpec=root.cronjobSpec,
   ):: {
     local vols = if std.length(volumes) > 0 then
       {
@@ -124,7 +125,7 @@ cfg {
           },
         },
       },
-    },
+    } + cronjobSpec,
   },
 
   job(

--- a/test_cases.json
+++ b/test_cases.json
@@ -240,5 +240,14 @@
 				"expected": "kill -15 -1"
 			}
 		]
+	},
+	{
+		"show_args": "./example/k8s/cronjob.jsonnet",
+		"asserts": [
+			{
+				"jq_path": ".spec.concurrencyPolicy",
+				"expected": "Forbid"
+			}
+		]
 	}
 ]


### PR DESCRIPTION
Allow overwrite spec

```
Testing ./plantbuild show ./example/k8s/tests/test_set_images.jsonnet -v 1.2.3
test.sh: line 29: printf: -n: invalid option
printf: usage: printf [-v var] format [arguments]
test.sh: line 30: printf: -n: invalid option
printf: usage: printf [-v var] format [arguments]
.

Testing ./plantbuild show ./example/build.jsonnet -v 1.0.0
.

Testing ./plantbuild show ./example/dep.jsonnet -v 1.0.0
.

Testing ./plantbuild show ./example/test_customized_deps.jsonnet -v 1.0.0
.

Testing ./plantbuild show ./example/test.jsonnet -v 1.0.0
.

Testing ./plantbuild show ./example/k8s/app1.jsonnet -v 1.0.0
.

Testing ./plantbuild show ./example/k8s/all.jsonnet -v 2.1.0
..

Testing ./plantbuild show ./example/k8s/tests/test_probe_cm.jsonnet
.

Testing ./plantbuild show ./example/k8s/tests/test_multi_hosts.jsonnet
.

Testing ./plantbuild show ./example/k8s/tests/test_configmap_envmap_pullsecrets.jsonnet
......

Testing ./plantbuild show ./example/k8s/tests/test_change_default_namespace.jsonnet
.......

Testing ./plantbuild show ./example/k8s/tests/test_volumes.jsonnet
..

Testing ./plantbuild show ./example/k8s/tests/test_image_without_tag_default_to_githash.jsonnet
.

Testing ./plantbuild show ./example/k8s/tests/test_image2url_with_hpa.jsonnet
...

Testing ./plantbuild show ./example/k8s/tests/test_deployment_with_hpa.jsonnet
...

Testing ./plantbuild show ./example/k8s/tests/test_job.jsonnet
.

Testing ./plantbuild show ./example/k8s/tests/test_pod_spec.jsonnet
...

Testing ./plantbuild show ./example/k8s/tests/test_container_lifecycle.jsonnet
..

Testing ./plantbuild show ./example/k8s/cronjob.jsonnet
.
```