### PR TITLE
Support customize deployment strategy type

### DIFF
--- a/example/k8s/tests/test_image2url_without_rolling_update.jsonnet
+++ b/example/k8s/tests/test_image2url_without_rolling_update.jsonnet
@@ -1,0 +1,11 @@
+local k8s = import 'k8s.jsonnet';
+
+k8s.list([
+  k8s.image_to_url(
+    namespace='example',
+    name='demo',
+    host='demo.example.theplant-dev.com',
+    path='/',
+    withoutRollingUpdate=true
+  ),
+])

--- a/jsonnetlib/config.jsonnet
+++ b/jsonnetlib/config.jsonnet
@@ -27,7 +27,6 @@ assert std.length(v) > 0 : 'version is empty';
   terminationGracePeriodSeconds: 30,
   ingressClassName: 'nginx',
   pathType: 'ImplementationSpecific',
-  strategyType: 'RollingUpdate',
 
   // config helper func
   local root = self,

--- a/jsonnetlib/config.jsonnet
+++ b/jsonnetlib/config.jsonnet
@@ -27,6 +27,7 @@ assert std.length(v) > 0 : 'version is empty';
   terminationGracePeriodSeconds: 30,
   ingressClassName: 'nginx',
   pathType: 'ImplementationSpecific',
+  strategyType: 'RollingUpdate',
 
   // config helper func
   local root = self,

--- a/jsonnetlib/k8s.jsonnet
+++ b/jsonnetlib/k8s.jsonnet
@@ -334,6 +334,7 @@ cfg {
     maxReplicas=3,
     targetCPUUtilizationPercentage=75,
     podSpec=root.podSpec,
+    strategyType=root.strategyType,
   ):: {
     apiVersion: 'v1',
     kind: 'List',
@@ -359,6 +360,7 @@ cfg {
         volumes=volumes,
         terminationGracePeriodSeconds=terminationGracePeriodSeconds,
         podSpec=podSpec,
+        strategyType=strategyType,
       ),
       root.svc(namespace, name, port, targetPort),
       root.single_svc_ingress(
@@ -476,6 +478,7 @@ cfg {
     volumes=[],
     terminationGracePeriodSeconds=root.terminationGracePeriodSeconds,
     podSpec=root.podSpec,
+    strategyType=root.strategyType
   ):: {
     local labels = { app: name },
     local probe = if withoutProbe then {}
@@ -548,7 +551,7 @@ cfg {
           maxSurge: maxSurge,
           maxUnavailable: 0,
         },
-        type: 'RollingUpdate',
+        type: strategyType,
       },
       selector: {
         matchLabels: labels,

--- a/test_cases.json
+++ b/test_cases.json
@@ -257,5 +257,18 @@
 				"expected": "500m"
 			}
 		]
+	},
+	{
+		"show_args": "./example/k8s/tests/test_image2url_without_rolling_update.jsonnet",
+		"asserts": [
+			{
+				"jq_path": ".items[0].spec.strategy.type",
+				"expected": "Recreate"
+			},
+			{
+				"jq_path": ".items[0].spec.strategy.rollingUpdate",
+				"expected": null
+			}
+		]
 	}
 ]


### PR DESCRIPTION
Support disable rolling update (`.spec.strategy.type` can be `Recreate`)
* Default: `.spec.strategy.type` = `RollingUpdate`
* Disable rolling update:  set `withoutRollingUpdate` = `true`

Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy