### PR TITLE
Add backoffLimit configuration to CronJob spec

### DIFF
--- a/jsonnetlib/k8s.jsonnet
+++ b/jsonnetlib/k8s.jsonnet
@@ -82,6 +82,7 @@ cfg {
     cpuLimit=root.cronCPULimit,
     memoryRequest=root.cronMemoryRequest,
     memoryLimit=root.cronMemoryLimit,
+    backoffLimit=0,
   ):: {
     local vols = if std.length(volumes) > 0 then
       {
@@ -109,7 +110,7 @@ cfg {
           },
         },
         spec: {
-          backoffLimit: 0,
+          backoffLimit: backoffLimit,
           template: {
             metadata: {
               labels: {


### PR DESCRIPTION
This commit introduces the ability to dynamically configure the `backoffLimit` for CronJobs in the k8s.jsonnet library. The backoffLimit can now be passed as a parameter, allowing for customizable retry behavior.

JIRA: https://theplanttokyo.atlassian.net/browse/SRE-4101
