### PR TITLE
feat(k8s): add TTL configuration for CronJob resources

### DIFF
--- a/jsonnetlib/k8s.jsonnet
+++ b/jsonnetlib/k8s.jsonnet
@@ -83,10 +83,15 @@ cfg {
     memoryRequest=root.cronMemoryRequest,
     memoryLimit=root.cronMemoryLimit,
     backoffLimit=0,
+    ttl=null,
   ):: {
     local vols = if std.length(volumes) > 0 then
       {
         volumes: volumes,
+      } else {},
+    local ttlConfig = if ttl != null then
+      {
+        ttlSecondsAfterFinished: ttl,
       } else {},
     kind: 'CronJob',
     apiVersion: 'batch/v1',
@@ -139,7 +144,7 @@ cfg {
             } + vols + imagePullSecretsRef(imagePullSecrets) + podSpec,
           },
         },
-      },
+      } + ttlConfig,
     } + cronjobSpec,
   },
 


### PR DESCRIPTION
Add support for setting ttlSecondsAfterFinished parameter in CronJob resources by introducing an optional ttl parameter defaulting to null. This allows automatic cleanup of completed jobs after a specified time.

