### PR TITLE
fix(k8s): move ttlSecondsAfterFinished to proper location in CronJob spec

### DIFF
--- a/jsonnetlib/config.jsonnet
+++ b/jsonnetlib/config.jsonnet
@@ -28,6 +28,7 @@ assert std.length(v) > 0 : 'version is empty';
   ingressClassName: 'nginx',
   pathType: 'ImplementationSpecific',
   jobTTL: 1800,
+  cronjobTTL: 3600,
 
   // config helper func
   local root = self,

--- a/jsonnetlib/k8s.jsonnet
+++ b/jsonnetlib/k8s.jsonnet
@@ -83,15 +83,11 @@ cfg {
     memoryRequest=root.cronMemoryRequest,
     memoryLimit=root.cronMemoryLimit,
     backoffLimit=0,
-    ttl=null,
+    ttl=3600,
   ):: {
     local vols = if std.length(volumes) > 0 then
       {
         volumes: volumes,
-      } else {},
-    local ttlConfig = if ttl != null then
-      {
-        ttlSecondsAfterFinished: ttl,
       } else {},
     kind: 'CronJob',
     apiVersion: 'batch/v1',
@@ -115,6 +111,7 @@ cfg {
           },
         },
         spec: {
+          ttlSecondsAfterFinished: ttl,
           backoffLimit: backoffLimit,
           template: {
             metadata: {
@@ -144,7 +141,7 @@ cfg {
             } + vols + imagePullSecretsRef(imagePullSecrets) + podSpec,
           },
         },
-      } + ttlConfig,
+      },
     } + cronjobSpec,
   },
 

--- a/jsonnetlib/k8s.jsonnet
+++ b/jsonnetlib/k8s.jsonnet
@@ -83,7 +83,7 @@ cfg {
     memoryRequest=root.cronMemoryRequest,
     memoryLimit=root.cronMemoryLimit,
     backoffLimit=0,
-    ttl=3600,
+    ttl=root.jobTTL,
   ):: {
     local vols = if std.length(volumes) > 0 then
       {

--- a/jsonnetlib/k8s.jsonnet
+++ b/jsonnetlib/k8s.jsonnet
@@ -83,7 +83,7 @@ cfg {
     memoryRequest=root.cronMemoryRequest,
     memoryLimit=root.cronMemoryLimit,
     backoffLimit=0,
-    ttl=root.jobTTL,
+    ttl=root.cronjobTTL,
   ):: {
     local vols = if std.length(volumes) > 0 then
       {


### PR DESCRIPTION
The ttlSecondsAfterFinished field was incorrectly being added to the job template object. Fixed by moving it to the job spec where it belongs and setting a default value of 3600 seconds (1 hour).
