### PR TITLE
fix(k8s): Skip HPA creation when min and max replicas are equal

### DIFF
--- a/jsonnetlib/k8s.jsonnet
+++ b/jsonnetlib/k8s.jsonnet
@@ -374,7 +374,7 @@ cfg {
         path=path,
         annotations=ingressAnnotations,
       ),
-    ] + (if replicas > 1 && maxReplicas > 1 then [
+    ] + (if replicas > 1 && maxReplicas > 1 && maxReplicas > minReplicas then [
            root.hpa(namespace, name, minReplicas, maxReplicas, targetCPUUtilizationPercentage),
          ] else []) + if replicas > 1 then [
       root.pdb(namespace, name, minAvailable),


### PR DESCRIPTION
The Horizontal Pod Autoscaler should only be created when there's actually a scaling range (when maxReplicas > minReplicas). Previously, we were creating HPAs even when these values were equal, which is unnecessary since no actual scaling can occur in that case.

This also provides a more elegant solution to remove the HPA. I stupidly thought that we can remove the HPA if we remove the `maxReplicas` and `minReplicas` arguments (theplant/lacoste-provisioning#2185), but it's not true.
