### PR TITLE
feat(k8s): Add support for generateName in Job resources

### DIFF
--- a/jsonnetlib/k8s.jsonnet
+++ b/jsonnetlib/k8s.jsonnet
@@ -156,12 +156,13 @@ cfg {
     container={},
     podSpec=root.podSpec,
     ttl=root.jobTTL,
+    generateName=false,
   ):: {
     kind: 'Job',
     apiVersion: 'batch/v1',
     metadata: {
       namespace: namespace,
-      name: name,
+      [if generateName then 'generateName' else 'name']: if generateName then '%s-' % name else name,
       labels: {
         app: name,
         job: name,


### PR DESCRIPTION
Introduce a new boolean parameter `generateName` to the Job function that allows switching between using `name` (default) and `generateName` in the Job metadata. When `generateName` is true, Kubernetes will auto-generate a unique suffix for each Job instance, which is useful for recurring or programmatically created Jobs to prevent name conflicts.

JIRA: https://theplanttokyo.atlassian.net/browse/SRE-4861

