### PR TITLE
Add headless parameter

### DIFF
--- a/jsonnetlib/k8s.jsonnet
+++ b/jsonnetlib/k8s.jsonnet
@@ -379,17 +379,13 @@ cfg {
         path=path,
         annotations=ingressAnnotations,
       ),
-    ] 
-    + (if hpaEnabled then [
+    ] + (if hpaEnabled then [
            root.hpa(namespace, name, minReplicas, maxReplicas, targetCPUUtilizationPercentage),
-         ] else []) 
-    + (if replicas > 1 then [
-      root.pdb(namespace, name, minAvailable),
-    ] else [])
-    + (if headlessEnabled then [
-           root.svc(namespace, name + "-hl", port, targetPort, headlessEnabled=headlessEnabled),
-         ] else []) 
-    ,
+         ] else []) + (if replicas > 1 then [
+                         root.pdb(namespace, name, minAvailable),
+                       ] else []) + (if headlessEnabled then [
+                                       root.svc(namespace, name + '-hl', port, targetPort, headlessEnabled=headlessEnabled),
+                                     ] else []),
   },
 
   svc(namespace=root.defaultNamespace, name, port=root.port, targetPort=root.port, annotations={}, headlessEnabled=false):: {
@@ -416,9 +412,8 @@ cfg {
         app: name,
       },
     },
-  } 
-  + {
-  spec+: if headlessEnabled then { clusterIP: 'None' } else {}
+  } + {
+    spec+: if headlessEnabled then { clusterIP: 'None' } else {},
   },
 
   single_svc_ingress(namespace=root.defaultNamespace, name, port, host='', path='/', ingressTLSEnabled=false, annotations={})::


### PR DESCRIPTION
https://theplanttokyo.atlassian.net/browse/SRE-5263

```jsonnet
local env = import './env/ec-demo.jsonnet';
local secretDB = import './secrets/db-params-ec-demo.jsonnet';
local image_tag = import 'ec-demo-image.jsonnet';
local k8s = import 'k8s.jsonnet';

k8s.list([
  k8s.image_to_url(
    namespace='test-qor5',
    name='ec-demo',
    host='ec-demo.qor5.theplant-dev.com',
    image='562055475000.dkr.ecr.ap-northeast-1.amazonaws.com/qor5/ec-demo:' + image_tag,
    path='/',
    targetPort=8181,
    headlessEnabled=true,
    // ...
    )
])
```

```shell
plantbuild show all.jsonnet
```

```json
      {
         "apiVersion": "v1",
         "kind": "Service",
         "metadata": {
            "annotations": { },
            "labels": {
               "app": "ec-demo"
            },
            "name": "ec-demo",
            "namespace": "test-qor5"
         },
         "spec": {
            "ports": [
               {
                  "name": "app",
                  "port": 4000,
                  "targetPort": 8181
               }
            ],
            "selector": {
               "app": "ec-demo"
            },
            "type": "ClusterIP"
         }
      },

      {
         "apiVersion": "v1",
         "kind": "Service",
         "metadata": {
            "annotations": { },
            "labels": {
               "app": "ec-demo-hl"
            },
            "name": "ec-demo-hl",
            "namespace": "test-qor5"
         },
         "spec": {
            "clusterIP": "None",
            "ports": [
               {
                  "name": "app",
                  "port": 4000,
                  "targetPort": 8181
               }
            ],
            "selector": {
               "app": "ec-demo-hl"
            },
            "type": "ClusterIP"
         }
      },
```