### PR TITLE
fix(k8s): fix headless service

### DIFF
--- a/jsonnetlib/k8s.jsonnet
+++ b/jsonnetlib/k8s.jsonnet
@@ -384,7 +384,7 @@ cfg {
          ] else []) + (if replicas > 1 then [
                          root.pdb(namespace, name, minAvailable),
                        ] else []) + (if headlessEnabled then [
-                                       root.svc(namespace, name + '-hl', port, targetPort, headlessEnabled=headlessEnabled),
+                                       root.svc(namespace, name, port, targetPort, headlessEnabled=headlessEnabled),
                                      ] else []),
   },
 
@@ -413,6 +413,7 @@ cfg {
       },
     },
   } + {
+    metadata+: if headlessEnabled then { name: name + '-hl' } else {},
     spec+: if headlessEnabled then { clusterIP: 'None' } else {},
   },
 


### PR DESCRIPTION
* before
```json
      {  
         "apiVersion": "v1",
         "kind": "Service",
         "metadata": {  
            "annotations": { },
            "labels": { 
               "app": "ec-demo-hl"
            },    
            "name": "ec-demo-hl",
            "namespace": "test-qor5"
         },    
         "spec": {
            "clusterIP": "None",
            "ports": [
               {
                  "name": "app",
                  "port": 4000,
                  "targetPort": 8181
               }
            ], 
            "selector": {
               "app": "ec-demo-hl"
            },
            "type": "ClusterIP"
         }  
      },
```

* after
```json
      {  
         "apiVersion": "v1",
         "kind": "Service",
         "metadata": {  
            "annotations": { },
            "labels": { 
               "app": "ec-demo"
            },    
            "name": "ec-demo-hl",
            "namespace": "test-qor5"
         },    
         "spec": {
            "clusterIP": "None",
            "ports": [
               {
                  "name": "app",
                  "port": 4000,
                  "targetPort": 8181
               }
            ], 
            "selector": {
               "app": "ec-demo"
            },
            "type": "ClusterIP"
         }  
      },
```