### PR TITLE
feat(k8s): Add ArgoCD annotation to ignore resource updates

### DIFF
--- a/jsonnetlib/k8s.jsonnet
+++ b/jsonnetlib/k8s.jsonnet
@@ -109,6 +109,9 @@ cfg {
           labels: {
             app: name,
           },
+          annotations: {
+            'argocd.argoproj.io/ignore-resource-updates': 'true',
+          },
         },
         spec: {
           ttlSecondsAfterFinished: ttl,
@@ -117,6 +120,9 @@ cfg {
             metadata: {
               labels: {
                 app: name,
+              },
+              annotations: {
+                'argocd.argoproj.io/ignore-resource-updates': 'true',
               },
             },
             spec: {


### PR DESCRIPTION
Add the 'argocd.argoproj.io/ignore-resource-updates' annotation to
Kubernetes Job and Pod templates. This instructs ArgoCD to ignore
updates for these resources, which can significantly reduce ArgoCD's
CPU usage by preventing unnecessary reconciliation.

Refs: https://argo-cd.readthedocs.io/en/stable/operator-manual/reconcile/#ignoring-updates-for-untracked-resources
