### PR TITLE
feat(deps): update envoy-gateway-libsonnet to v1.7.1

### DIFF
--- a/jsonnetlib/jsonnetfile.json
+++ b/jsonnetlib/jsonnetfile.json
@@ -23,10 +23,10 @@
       "source": {
         "git": {
           "remote": "https://github.com/jsonnet-libs/envoy-gateway-libsonnet.git",
-          "subdir": "v1.7.0"
+          "subdir": "v1.7.1"
         }
       },
-      "version": "main"
+      "version": "41e88ead9ed5418f59f3823d5b424932b0668d18"
     }
   ],
   "legacyImports": true

--- a/jsonnetlib/jsonnetfile.lock.json
+++ b/jsonnetlib/jsonnetfile.lock.json
@@ -5,11 +5,11 @@
       "source": {
         "git": {
           "remote": "https://github.com/jsonnet-libs/envoy-gateway-libsonnet.git",
-          "subdir": "v1.7.0"
+          "subdir": "v1.7.1"
         }
       },
-      "version": "5f2419841aecafe8e9a450b27e238c280e8736a5",
-      "sum": "5lVlcIUHX0ZKNLO1cWeCfLbFO7MmucgG5fgN0OCZXCc="
+      "version": "41e88ead9ed5418f59f3823d5b424932b0668d18",
+      "sum": "htd4YMM0I2F8+PwoCVEv5cD/heCecmFe5mUeYMn7cuQ="
     },
     {
       "source": {


### PR DESCRIPTION
envoy-gateway-libsonnet removed the `v1.7.0` sub-directory on main
branch, to avoid breaking our build, we need to update the sub-directory to
`v1.7.1` and update the version to the commit hash.
