### PR TITLE
feat: switch from docker-compose to docker compose

### DIFF
--- a/plantbuild
+++ b/plantbuild
@@ -82,12 +82,12 @@ dockerimage='ghcr.io/theplant/plantbuild'
 push_image() {
     build_image "$1"
     # shellcheck disable=SC2086
-    docker run -i --rm -e RUN="/src/$filename" -e VERSION="$1" -v "$(pwd)/$dir:/src" "$dockerimage$buildversion" | docker-compose -f - push $dcservice
+    docker run -i --rm -e RUN="/src/$filename" -e VERSION="$1" -v "$(pwd)/$dir:/src" "$dockerimage$buildversion" | docker compose -f - push $dcservice
 }
 
 build_image() {
     # shellcheck disable=SC2086
-    docker run -i --rm -e RUN="/src/$filename" -e VERSION="$1" -v "$(pwd)/$dir:/src" "$dockerimage$buildversion" | docker-compose -f - build $dcservice
+    docker run -i --rm -e RUN="/src/$filename" -e VERSION="$1" -v "$(pwd)/$dir:/src" "$dockerimage$buildversion" | docker compose -f - build $dcservice
 }
 
 show() {
@@ -131,7 +131,7 @@ k8scommit() {
 case $subcommand in
 
 run)
-    docker run --rm -e RUN="/src/$filename" -e VERSION="$version" -v "$(pwd)/$dir:/src" "$dockerimage$buildversion" | docker-compose -f - run "$app"_test
+    docker run --rm -e RUN="/src/$filename" -e VERSION="$version" -v "$(pwd)/$dir:/src" "$dockerimage$buildversion" | docker compose -f - run "$app"_test
     ;;
 
 build)


### PR DESCRIPTION
- Replace all instances of `docker-compose` with `docker compose` to
  align with the latest Docker CLI recommendations.
- Ensures compatibility with newer Docker versions where `docker-compose`
  is deprecated in favor of the integrated `docker compose` command.

No breaking changes expected, but users must have a recent Docker CLI
installed (which we are).

Refs: https://docs.docker.com/retired/#docker-compose-v1-replaced-by-compose-v2
