### PR TITLE
fix: disable buildx provenance to dedup ECR images across tag pushes

### DIFF
--- a/plantbuild
+++ b/plantbuild
@@ -86,8 +86,12 @@ push_image() {
 }
 
 build_image() {
+    # BUILDX_NO_DEFAULT_ATTESTATIONS=1: `build`/`push` invoke build_image multiple times (per tag),
+    # and provenance attestations differ each run, producing distinct Image Indexes in ECR for
+    # identical content. We don't verify attestations anywhere, so disable them to dedup by digest.
+
     # shellcheck disable=SC2086
-    docker run -i --rm -e RUN="/src/$filename" -e VERSION="$1" -v "$(pwd)/$dir:/src" "$dockerimage$buildversion" | docker compose -f - build $dcservice
+    docker run -i --rm -e RUN="/src/$filename" -e VERSION="$1" -v "$(pwd)/$dir:/src" "$dockerimage$buildversion" | BUILDX_NO_DEFAULT_ATTESTATIONS=1 docker compose -f - build $dcservice
 }
 
 show() {


### PR DESCRIPTION
`build`/`push` invoke build_image once per tag (version, latest, git tag), and buildx's default provenance attestation embeds per-build timestamps — so identical content produces a different Image Index digest each run, and ECR shows N separate Image Indexes instead of one image with N tags. 

Since attestations aren't verified anywhere in our pipeline, set BUILDX_NO_DEFAULT_ATTESTATIONS=1 to emit a plain image manifest and let ECR dedup by digest.

Provide context or links (Jira ticket, Slack thread) for both the reviewer and your future self:
- Jira ticket: https://theplanttokyo.atlassian.net/browse/SRE-6025
