### PR TITLE
feat(k8s): add default startingDeadlineSeconds=300 to cronjob

### DIFF
--- a/jsonnetlib/k8s.jsonnet
+++ b/jsonnetlib/k8s.jsonnet
@@ -84,6 +84,7 @@ cfg {
     memoryLimit=root.cronMemoryLimit,
     backoffLimit=0,
     ttl=root.cronjobTTL,
+    startingDeadlineSeconds=300,
   ):: {
     local vols = if std.length(volumes) > 0 then
       {
@@ -101,6 +102,7 @@ cfg {
     },
     spec: {
       schedule: schedule,
+      startingDeadlineSeconds: startingDeadlineSeconds,
       concurrencyPolicy: 'Allow',
       failedJobsHistoryLimit: root.failedJobsHistoryLimit,
       successfulJobsHistoryLimit: root.successfulJobsHistoryLimit,


### PR DESCRIPTION
Provide context or links (Jira ticket, Slack thread) for both the reviewer and your future self:

- Jira ticket:
- Slack thread:

Ref: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#starting-deadline