### PR TITLE
jsonnetlib: Add option to disable HTTP listener in Gateway

### DIFF
--- a/jsonnetlib/k8s-new.jsonnet
+++ b/jsonnetlib/k8s-new.jsonnet
@@ -316,6 +316,7 @@ local k = import 'k.libsonnet';
     clusterIssuer='letsencrypt-gateway',
     extraListeners=[],
     compression=true,
+    enableHTTPListener=true,
   )::
     local gateway = gw_api.gateway.v1.gateway;
     local listeners = gateway.spec.listeners;
@@ -354,13 +355,14 @@ local k = import 'k.libsonnet';
       + gateway.metadata.withAnnotations({ 'cert-manager.io/cluster-issuer': clusterIssuer })
       + gateway.spec.withGatewayClassName(gatewayClassName)
       + gateway.spec.withListeners(
-        [
-          listeners.withName('http')
-          + listeners.withPort(80)
-          + listeners.withProtocol('HTTP')
-          + listeners.allowedRoutes.namespaces.withFrom('Same'),
-          httpsListener,
-        ] + extraListeners
+        (if enableHTTPListener then [
+           listeners.withName('http')
+           + listeners.withPort(80)
+           + listeners.withProtocol('HTTP')
+           + listeners.allowedRoutes.namespaces.withFrom('Same'),
+         ] else [])
+        + [httpsListener]
+        + extraListeners
       );
 
     local route =
@@ -398,7 +400,8 @@ local k = import 'k.libsonnet';
                   + backendTrafficPolicy.spec.compressor.withMinContentLength(1024),
                 ]);
 
-    local items = [gw, route]
+    local items = [gw]
+                  + (if enableHTTPListener then [route] else [])
                   + (if compression then [btp] else [])
                   + (if enableCloudfrontIPDetection then [
                        clientTrafficPolicy.new(name + '-cloudfront-trusted-ips')


### PR DESCRIPTION
Introduce the `enableHTTPListener` parameter to provide control over the
creation of the default port 80 listener and its associated route.

When set to false, the Gateway will no longer expose port 80 and will
omit the default HTTP route. This allows for more restrictive Gateway
configurations where only HTTPS or custom listeners are required.

Slack: https://theplant.slack.com/archives/C011SF22G4S/p1782700426695649
