### PR TITLE
k8s: Add `allowedListenerSetNamespaces` to Gateway

### DIFF
--- a/jsonnetlib/k8s-new.jsonnet
+++ b/jsonnetlib/k8s-new.jsonnet
@@ -328,6 +328,11 @@ local k = import 'k.libsonnet';
     extraListeners=[],
     compression=true,
     enableHTTPListener=true,
+    // Controls whether ListenerSets may attach to this Gateway (spec.allowedListeners).
+    //   null            -> omit allowedListeners (API default: no ListenerSets allowed)
+    //   'Same' / 'All'  -> allow ListenerSets from the same / all namespaces
+    //   [ns, ...]       -> allow ListenerSets from the listed namespaces (Selector)
+    allowedListenerSetNamespaces=null,
   )::
     local gateway = gw_api.gateway.v1.gateway;
     local listeners = gateway.spec.listeners;
@@ -360,6 +365,18 @@ local k = import 'k.libsonnet';
         + tls.certificateRefs.withKind('Secret'),
       ]);
 
+    local allowedListeners =
+      if allowedListenerSetNamespaces == null then {}
+      else if std.type(allowedListenerSetNamespaces) == 'array' then
+        gateway.spec.allowedListeners.namespaces.withFrom('Selector')
+        + gateway.spec.allowedListeners.namespaces.selector.withMatchExpressions([{
+          key: 'kubernetes.io/metadata.name',
+          operator: 'In',
+          values: allowedListenerSetNamespaces,
+        }])
+      else
+        gateway.spec.allowedListeners.namespaces.withFrom(allowedListenerSetNamespaces);
+
     local gw =
       gateway.new(name)
       + gateway.metadata.withNamespace(namespace)
@@ -374,7 +391,8 @@ local k = import 'k.libsonnet';
          ] else [])
         + [httpsListener]
         + extraListeners
-      );
+      )
+      + allowedListeners;
 
     local route =
       httpRoute.new(name + '-tls-redirect')


### PR DESCRIPTION
Introduce the `allowedListenerSetNamespaces` parameter to allow
fine-grained control over which namespaces can attach ListenerSets to the
generated Gateway.

This update supports three configuration modes:
- `null` (default): Omits the field, relying on Gateway API defaults.
- `'Same'` / `'All'`: Sets the namespace attachment policy directly.
- Array of strings: Automatically constructs a label selector targeting
  the `kubernetes.io/metadata.name` label for the specified namespaces.

Slack: https://theplant.slack.com/archives/C011SF22G4S/p1782722336183989?thread_ts=1782700426.695649&cid=C011SF22G4S
