### PR TITLE
jsonnetlib: Default version to 'latest' if VERSION is empty

### DIFF
--- a/jsonnetlib/config.jsonnet
+++ b/jsonnetlib/config.jsonnet
@@ -1,8 +1,7 @@
 local v = std.extVar('VERSION');
-assert std.length(v) > 0 : 'version is empty';
 
 {
-  version: v,
+  version: if std.length(v) > 0 then v else 'latest',
   dockerRegistry: 'registry.example.com',
   imagePullSecrets: '',
   defaultNamespace: 'default',


### PR DESCRIPTION
Remove the strict assertion that the VERSION external variable must be
non-empty. Instead, fallback to 'latest' as a default value when the
provided version string is empty.

We don't need this VERSION when building the manifest.
