### PR TITLE
plantbuild: support jsonnet libraries vendored with jsonnet-bundler

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,48 @@ It utilize a docker image published at `ghcr.io/theplant/plantbuild:latest`, Thi
 sudo curl -fsSL https://raw.githubusercontent.com/theplant/plantbuild/master/plantbuild > /usr/local/bin/plantbuild && sudo chmod +x /usr/local/bin/plantbuild
 ```
 
+## Vendoring the jsonnet libraries with jsonnet-bundler
+
+By default plantbuild generates manifests by running jsonnet inside the
+`ghcr.io/theplant/plantbuild` image, using the `jsonnetlib` baked into that image.
+
+Alternatively a project can pin the libraries itself with
+[jsonnet-bundler](https://github.com/jsonnet-bundler/jsonnet-bundler). Put a
+`jsonnetfile.json` in the root of your project:
+
+```json
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/theplant/plantbuild.git",
+          "subdir": "jsonnetlib"
+        }
+      },
+      "version": "master"
+    }
+  ],
+  "legacyImports": true
+}
+```
+
+When plantbuild finds a `jsonnetfile.json` in the current directory it will:
+
+- download `jb` and `jsonnet` if they are not already on `PATH` (into a temp directory that
+  is removed on exit, so a fresh CI container needs no preinstalled toolchain)
+- run `jb install` to populate `vendor/`
+- generate manifests locally with `jsonnet -J vendor/jsonnetlib/ -J vendor/ -V VERSION=...`
+  instead of running the docker image
+
+`imports` keep working unchanged (`import 'k8s.jsonnet'`), and transitive dependencies of
+`jsonnetlib` (k8s-libsonnet, gateway-api-libsonnet, ...) resolve through `-J vendor/`.
+Projects without a `jsonnetfile.json` are unaffected and keep using the docker image.
+
+The downloaded tool versions can be overridden with the `JB_VERSION` and `JSONNET_VERSION`
+environment variables.
+
 ## Command Manual
 
 plantbuild -- Test, Build, Push images, and Deploy to kubernetes cluster

--- a/fmt-check.sh
+++ b/fmt-check.sh
@@ -4,7 +4,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if ! find . -name '*.jsonnet' -exec jsonnetfmt --test '{}' +
+# vendor/ holds jsonnet-bundler dependencies, they are not ours to format
+if ! find . -name vendor -prune -o -name '*.jsonnet' -exec jsonnetfmt --test '{}' +
 then
   echo "ERROR: found unformatted jsonnet files. Fix with plantbuild fmt-update"
   exit 1

--- a/fmt-update.sh
+++ b/fmt-update.sh
@@ -4,4 +4,5 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-find . -name '*.jsonnet' -exec jsonnetfmt -i '{}' +
+# vendor/ holds jsonnet-bundler dependencies, they are not ours to format
+find . -name vendor -prune -o -name '*.jsonnet' -exec jsonnetfmt -i '{}' +

--- a/plantbuild
+++ b/plantbuild
@@ -62,6 +62,104 @@ if ! [ -e "$jsonnetfile" ]; then
     exit 1
 fi
 
+# Versions of the tools downloaded on demand for vendored (jsonnetfile.json) projects.
+JB_VERSION=${JB_VERSION:-v0.6.0}
+JSONNET_VERSION=${JSONNET_VERSION:-v0.22.0}
+
+# Downloaded tools live in a temp dir for the duration of this run only: plantbuild runs in
+# a fresh container each time, so there is nothing to gain from caching them on disk.
+tools_bin=
+
+os=
+arch=
+
+detect_platform() {
+    if [ -n "$os" ]; then
+        return
+    fi
+    case $(uname -s) in
+    Linux) os=linux ;;
+    Darwin) os=darwin ;;
+    *)
+        echo "unsupported os: $(uname -s)" >&2
+        exit 1
+        ;;
+    esac
+    case $(uname -m) in
+    x86_64 | amd64) arch=amd64 ;;
+    arm64 | aarch64) arch=arm64 ;;
+    *)
+        echo "unsupported architecture: $(uname -m)" >&2
+        exit 1
+        ;;
+    esac
+}
+
+# download <url> [output file, default stdout]
+# curl is not in every CI base image (alpine ships wget), so accept either.
+download() {
+    local url=$1
+    local out=${2:--}
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL --connect-timeout 10 --retry 3 -o "$out" "$url"
+    elif command -v wget >/dev/null 2>&1; then
+        wget -q -O "$out" "$url"
+    else
+        echo "neither curl nor wget is available to download $url" >&2
+        exit 1
+    fi
+}
+
+install_jb() {
+    local into=$1
+    download \
+        "https://github.com/jsonnet-bundler/jsonnet-bundler/releases/download/$JB_VERSION/jb-$os-$arch" \
+        "$into/jb"
+}
+
+install_jsonnet() {
+    local into=$1
+    download "https://github.com/google/go-jsonnet/releases/download/$JSONNET_VERSION/go-jsonnet_${JSONNET_VERSION#v}_${os}_${arch}.tar.gz" |
+        tar -xz -C "$into" jsonnet
+}
+
+# ensure_tool <command> <version> <install function>
+# Uses <command> from PATH when available, otherwise downloads it from its github release
+# into a temp dir that is put on PATH and removed when plantbuild exits.
+ensure_tool() {
+    local cmd=$1
+    local toolversion=$2
+    local installer=$3
+
+    if command -v "$cmd" >/dev/null 2>&1; then
+        return
+    fi
+
+    detect_platform
+
+    if [ -z "$tools_bin" ]; then
+        tools_bin=$(mktemp -d)
+        trap 'rm -rf "$tools_bin"' EXIT
+        export PATH="$tools_bin:$PATH"
+    fi
+
+    # to stderr: stdout of every subcommand must stay a clean manifest for jq/kubectl
+    echo "$cmd not found, downloading $cmd $toolversion" >&2
+    "$installer" "$tools_bin"
+    chmod +x "$tools_bin/$cmd"
+}
+
+# A jsonnetfile.json in the current directory means the jsonnet libraries (plantbuild's
+# jsonnetlib included) are vendored with jsonnet-bundler, so jsonnet runs locally against
+# ./vendor instead of running inside the plantbuild docker image.
+vendored=false
+if [ -f jsonnetfile.json ]; then
+    vendored=true
+    ensure_tool jb "$JB_VERSION" install_jb
+    ensure_tool jsonnet "$JSONNET_VERSION" install_jsonnet
+    jb install >&2
+fi
+
 githash7=$(git rev-parse HEAD | cut -c 1-7)
 if [ -z "$version" ]; then
     version=$githash7
@@ -82,7 +180,7 @@ dockerimage='ghcr.io/theplant/plantbuild'
 push_image() {
     build_image "$1"
     # shellcheck disable=SC2086
-    docker run -i --rm -e RUN="/src/$filename" -e VERSION="$1" -v "$(pwd)/$dir:/src" "$dockerimage$buildversion" | docker compose -f - push $dcservice
+    show "$1" "$filename" | docker compose -f - push $dcservice
 }
 
 build_image() {
@@ -91,11 +189,22 @@ build_image() {
     # identical content. We don't verify attestations anywhere, so disable them to dedup by digest.
 
     # shellcheck disable=SC2086
-    docker run -i --rm -e RUN="/src/$filename" -e VERSION="$1" -v "$(pwd)/$dir:/src" "$dockerimage$buildversion" | BUILDX_NO_DEFAULT_ATTESTATIONS=1 docker compose -f - build $dcservice
+    show "$1" "$filename" | BUILDX_NO_DEFAULT_ATTESTATIONS=1 docker compose -f - build $dcservice
 }
 
+# show <version> <jsonnet file relative to $dir, or - for stdin>
 show() {
-    local source=/src/$2
+    local source
+    if [ "$vendored" = true ]; then
+        source=$dir/$2
+        if [ "$2" = '-' ]; then
+            source='-'
+        fi
+        jsonnet -J vendor/jsonnetlib/ -J vendor/ -V VERSION="$1" "$source"
+        return
+    fi
+
+    source=/src/$2
     if [ "$2" = '-' ]; then
         source='-'
     fi
@@ -135,7 +244,7 @@ k8scommit() {
 case $subcommand in
 
 run)
-    docker run --rm -e RUN="/src/$filename" -e VERSION="$version" -v "$(pwd)/$dir:/src" "$dockerimage$buildversion" | docker compose -f - run "$app"_test
+    show "$version" "$filename" | docker compose -f - run "$app"_test
     ;;
 
 build)


### PR DESCRIPTION
When a jsonnetfile.json is present in the current directory, generate
manifests locally with

jsonnet -J vendor/jsonnetlib/ -J vendor/ -V VERSION=...

instead of running jsonnet inside the ghcr.io/theplant/plantbuild image,
so a project can pin jsonnetlib and its transitive dependencies itself.
jb install runs first to populate vendor/.

jb and jsonnet are taken from PATH when available, otherwise downloaded
from their github release assets into a temp dir that is put on PATH and
removed on exit. plantbuild always runs in a fresh container, so there is
nothing worth caching between runs; this keeps a cold start free of any
preinstalled toolchain (no Go needed, curl or wget). Versions are
overridable via JB_VERSION and JSONNET_VERSION.

build/push/run now generate through show() instead of repeating the
docker invocation, otherwise they would keep rendering inside the image
and fail on any vendored import. Diagnostics all go to stderr so stdout
stays a clean manifest for jq and kubectl.

Projects without a jsonnetfile.json keep the previous docker behaviour.

Also prune vendor/ in fmt-check/fmt-update: a vendor/ dir at the project
root puts third-party .jsonnet files in find's path, and fmt-update would
rewrite them in place.
