### PR TITLE
jsonnetlib: pass through startupProbe, and stop requiring liveness+readiness together

### DIFF
--- a/jsonnetlib/k8s-new.jsonnet
+++ b/jsonnetlib/k8s-new.jsonnet
@@ -49,8 +49,13 @@ local k = import 'k.libsonnet';
     // Default probe configuration
     local lp = ctn.livenessProbe;
     local rp = ctn.readinessProbe;
+    // 注意：调用方一旦传了 probes，下面的默认值就**整体**不生效（这是替换，
+    // 不是 merge）。所以传 probes 时必须把每个参数都写全，否则会静默落到
+    // Kubernetes 的裸默认值（timeoutSeconds=1 / initialDelaySeconds=0）上。
     local defaultProbe = if withoutProbe then {}
-    else if std.objectHas(probes, 'livenessProbe') || std.objectHas(probes, 'readinessProbe') then probes
+    else if std.objectHas(probes, 'livenessProbe')
+            || std.objectHas(probes, 'readinessProbe')
+            || std.objectHas(probes, 'startupProbe') then probes
     else lp.tcpSocket.withPort(normalizedPorts[0].containerPort)
          + lp.withFailureThreshold(3)
          + lp.withInitialDelaySeconds(360)
@@ -72,8 +77,17 @@ local k = import 'k.libsonnet';
         + ctn.withPorts(normalizedPorts)
         + ctn.resources.withLimits(limits)
         + ctn.resources.withRequests(requests)
-        + (if !withoutProbe then { livenessProbe: defaultProbe.livenessProbe } else {})
-        + (if !withoutProbe then { readinessProbe: defaultProbe.readinessProbe } else {})
+        // 三个 probe 都按存在与否透传：此前 liveness / readiness 是无条件取
+        // defaultProbe.<name> 的，调用方只传其中一个就会 field does not exist。
+        + (if !withoutProbe && std.objectHas(defaultProbe, 'livenessProbe')
+           then { livenessProbe: defaultProbe.livenessProbe } else {})
+        + (if !withoutProbe && std.objectHas(defaultProbe, 'readinessProbe')
+           then { readinessProbe: defaultProbe.readinessProbe } else {})
+        // startupProbe 一旦通过，liveness / readiness 才开始执行，因此能同时满足
+        // 「启动期宽容」和「运行期敏感」——用 initialDelaySeconds 只能二选一
+        // （那是死等：服务早就起来了，liveness 在整个宽限期内仍然不工作）。
+        + (if !withoutProbe && std.objectHas(defaultProbe, 'startupProbe')
+           then { startupProbe: defaultProbe.startupProbe } else {})
         + ctn.withEnvMap(envmap)
         + container,
       ],


### PR DESCRIPTION
两处改动，都在 `k8s-new.jsonnet` 的 probe 装配。

## 1. 透传 `startupProbe`（新能力）

此前只透传 `livenessProbe` 和 `readinessProbe` 两个字段，调用方即便在 `probes` 里写了 `startupProbe` 也会被**静默丢弃**。

`startupProbe` 一旦通过，liveness / readiness 才开始执行，因此能同时满足「启动期宽容」和「运行期敏感」这两个本来冲突的要求。用 `initialDelaySeconds` 只能二选一——那是**死等**：服务 3 秒就起来了，整个宽限期内 liveness 仍然不工作，处于无保护状态。

起因是 mad-provisioning 的四个服务想改用 startupProbe 但接不上（theplant/mad-provisioning#123）。

## 2. 三个 probe 都按存在与否透传（顺带修 bug）

原来是无条件取 `defaultProbe.livenessProbe` / `defaultProbe.readinessProbe`，而进入这条分支的条件是「传了其中**任意一个**」。于是只传 `readinessProbe` 就会炸：

```
RUNTIME ERROR: field does not exist: livenessProbe
	k8s-new.jsonnet:75:51-77
```

现在三个都用 `std.objectHas` 保护，传几个就渲染几个。

## 渲染验证

`jb install` 后用 jsonnet 实跑四种组合：

| 调用方式 | 结果 | |
|---|---|---|
| 不传 `probes` | liveness + readiness，`initialDelaySeconds=360` | 不变 |
| 只传 liveness + readiness | 原样透传，无 startupProbe | 不变 |
| 三个都传 | **startupProbe 出现** | 新增 |
| 只传 readiness | 正常渲染 | **修复**（改动前 RUNTIME ERROR） |

**前两条覆盖了全部现网调用方式，行为逐字未变，向后兼容。**

## 附带：给 defaultProbe 加了注释

说明「传 `probes` 会**整体替换**默认值而不是 merge」。这个语义踩过坑：mad-provisioning 的四个服务只写了 `httpGet` 没写参数，结果把库里的 `initialDelaySeconds=360` 整个丢掉，落到 Kubernetes 裸默认值 `timeoutSeconds=1` / `initialDelaySeconds=0` 上——20~30 秒就能判死一个容器，且启动稍慢就会 CrashLoopBackOff。